### PR TITLE
Fix breaking error in ATEnocov

### DIFF
--- a/R/ATEnocov.R
+++ b/R/ATEnocov.R
@@ -69,9 +69,9 @@ ATEnocov <- function(Y, Z, data = parent.frame(), match = NULL){
     if (length(match) != length(Y))
       stop("`match' and `Y' have different numbers of observations")
     
+  res <- list(call = call, Y = Y, Z = Z, match = match)
   ## ATE for unit randomization
   res$ATE.est <- mean(Y[Z==1])-mean(Y[Z==0])
-  res <- list(call = call, Y = Y, Z = Z, match = match)
   if (is.null(match)) { # without matching
     res$ATE.var <- var(Y[Z==1])/sum(Z==1)+var(Y[Z==0])/sum(Z==0)
   } else { # with matching


### PR DESCRIPTION
Hi!

I noticed that `ATEnocov()` doesn't work because you try to add the ATE to `res` before `res` is initialized. This PR just moves initializing `res` above any assignment.

Old results:
```
> experiment::ATEnocov(mtcars$mpg, mtcars$am)
Error in experiment::ATEnocov(mtcars$mpg, mtcars$am) : 
  object 'res' not found
```

New results:
```
> experiment::ATEnocov(mtcars$mpg, mtcars$am)
$call
experiment::ATEnocov(Y = mtcars$mpg, Z = mtcars$am)

$Y
 [1] 21.0 21.0 22.8 21.4 18.7 18.1 14.3 24.4 22.8 19.2 17.8 16.4 17.3
[14] 15.2 10.4 10.4 14.7 32.4 30.4 33.9 21.5 15.5 15.2 13.3 19.2 27.3
[27] 26.0 30.4 15.8 19.7 15.0 21.4

$Z
 [1] 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 1 1 1 1 1 1 1

$match
NULL

$ATE.est
[1] 7.244939

$ATE.var
[1] 3.698706

attr(,"class")
[1] "ATEnocov"
```
